### PR TITLE
Update pandas to 2.2.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ gspread==6.1.2
 msal==1.29.0
 Office365-REST-Python-Client==2.5.5
 openpyxl==3.1.2
-pandas==2.0.3
+pandas==2.2.2


### PR DESCRIPTION
- Improve building time by using: pandas-2.2.2-cp39-cp39-musllinux_1_1_x86_64.whl.metadata