### PR TITLE
Refactor metadata profile rendering logic to improve conditional checks for GeoDCAT-AP/INSPIRE (spatial datasets) profiles

### DIFF
--- a/ckanext/schemingdcat/statistics/model.py
+++ b/ckanext/schemingdcat/statistics/model.py
@@ -46,7 +46,7 @@ def setup():
         define_tables()
 
     if not statistics_table.exists():
-        statistics_table.create()
+        statistics_table.create(checkfirst=True)
         log.debug('SchemingDCAT statistics table defined in DB')
 
 def clean():
@@ -62,10 +62,13 @@ def clean():
     """
     global statistics_table
 
-    if statistics_table is not None and statistics_table.exists():
-        statistics_table.drop()
-        log.debug('SchemingDCAT statistics table dropped from DB')
-
+    try:
+        if statistics_table is not None and statistics_table.exists():
+            statistics_table.drop(checkfirst=True)
+            log.debug('SchemingDCAT statistics table dropped from DB')
+    except Exception as e:
+        log.error('Error dropping statistics table: %s', e)
+    
     setup()
     
 def update_table():

--- a/ckanext/schemingdcat/templates/schemingdcat/package/snippets/download_metadata.html
+++ b/ckanext/schemingdcat/templates/schemingdcat/package/snippets/download_metadata.html
@@ -58,8 +58,10 @@
                     {% set added_profiles = [] %}
                     {% for profile in profiles %}
                         {% if profile.profile_label not in added_profiles %}
-                            {% if 'eu_dcat_ap' in profile.profile or (pkg.theme_es and 'es_dcat' in profile.profile) %}
-                                <li class="dropdown-header" title="{{ _('RDF DCAT Endpoint') }}"><i class="fa fa-share-alt"></i> {{ profile.profile_label }} - {{ _('Linked Data') }}</li>
+                            {% if ('eu_dcat_ap' in profile.profile or (pkg.theme_es and 'es_dcat' in profile.profile)) and not ('eu_geodcat_ap' in profile.profile and pkg.dcat_type not in inspire_metadata_values) %}
+                                <li class="dropdown-header" title="{{ _('RDF DCAT Endpoint') }}">
+                                    <i class="fa fa-share-alt"></i> {{ profile.profile_label }} - {{ _('Linked Data') }}
+                                </li>
                                 {% for link in linked_data_links if link.endpoint_type == 'dcat' %}
                                     {% set url = h.url_for(link.endpoint, profiles=profile.profile, **link.endpoint_data) %}
                                     {% set format_label = '<strong>' + link.format + '</strong>' %}

--- a/ckanext/schemingdcat/templates/schemingdcat/package/snippets/metadata_profiles_badges.html
+++ b/ckanext/schemingdcat/templates/schemingdcat/package/snippets/metadata_profiles_badges.html
@@ -12,7 +12,6 @@
 #}
 
 {% set processed_profiles = [] %}
-{% set has_geodcat_ap = false %}
 
 {% macro render_metadata_label(profile_label, profile_title, profile_info_url, profile_fa_icon) %}
   <div class="metadata-label pull-left">
@@ -31,24 +30,13 @@
     {% if profile_key not in processed_profiles %}
         {% if profile.profile_id == 'inspire' and pkg.dcat_type in inspire_metadata_values %}
             {{ render_metadata_label(profile.profile_label, profile.profile_label, profile.profile_info_url, profile.profile_fa_icon) }}
-        {% elif profile.profile_id == 'geodcat_ap' %}
+        {% elif profile.profile_id == 'geodcat_ap' and pkg.dcat_type in inspire_metadata_values %}
             {{ render_metadata_label('GeoDCAT-AP', profile.profile_label, profile.profile_info_url, profile.profile_fa_icon) }}
-            {% set has_geodcat_ap = True %}
+        {% elif profile.profile_id == 'dcat_ap' and pkg.dcat_type not in inspire_metadata_values %}
+            {{ render_metadata_label('DCAT-AP', profile.profile_label, profile.profile_info_url, profile.profile_fa_icon) }}
         {% elif profile.profile_id == 'nti_risp' and pkg.theme_es %}
             {{ render_metadata_label(profile.profile_label, profile.profile_label, profile.profile_info_url, profile.profile_fa_icon) }}
         {% endif %}
         {% set _ = processed_profiles.append(profile_key) %}
     {% endif %}
 {% endfor %}
-
-{% if not has_geodcat_ap %}
-    {% for profile in sorted_profiles %}
-        {% set profile_key = profile.profile_id if profile.profile_id else profile.profile_label %}
-        {% if profile_key not in processed_profiles %}
-            {% if profile.profile_id == 'dcat_ap' %}
-                {{ render_metadata_label('DCAT-AP', profile.profile_label, profile.profile_info_url, profile.profile_fa_icon) }}
-            {% endif %}
-            {% set _ = processed_profiles.append(profile_key) %}
-        {% endif %}
-    {% endfor %}
-{% endif %}

--- a/ckanext/schemingdcat/validators.py
+++ b/ckanext/schemingdcat/validators.py
@@ -1202,7 +1202,6 @@ def normalize_tag_strings(field, schema):
             
     return validator
 
-@staticmethod
 @lru_cache(maxsize=44)
 def normalize_string(s):
     """Normalizes a string according to the rules:


### PR DESCRIPTION
### Fixes
* `ckanext/schemingdcat/validators.py`: The `'staticmethod' object is not callable' error occurs because the `@staticmethod' decorator is used outside the context of a class (`normalize_string`) . The `@staticmethod' decorator only makes sense when applied to methods defined inside a class, as it makes the method static, allowing it to be called without instantiating the class.

### Refinements to metadata profiles display logic:

* `ckanext/schemingdcat/templates/schemingdcat/package/snippets/download_metadata.html`: Updated the condition to display the `RDF DCAT Endpoint` only if certain profiles are present and specific conditions are met.
* `ckanext/schemingdcat/templates/schemingdcat/package/snippets/metadata_profiles_badges.html`: Added a check to ensure `geodcat_ap` profiles are displayed only if the package's `dcat_type` is in `inspire_metadata_values`.

### Code cleanup:

* `ckanext/schemingdcat/templates/schemingdcat/package/snippets/metadata_profiles_badges.html`: Removed the unnecessary `has_geodcat_ap` variable and the redundant loop that checked for `dcat_ap` profiles. 