### PR TITLE
Add API media type to file-type codelist and improve format handling in BaseEuDCATAPProfile for format BNodes

### DIFF
--- a/ckanext/schemingdcat/codelists/inspire/csv/file-type.csv
+++ b/ckanext/schemingdcat/codelists/inspire/csv/file-type.csv
@@ -1,4 +1,5 @@
 id,label,media_type
+,API,http://www.iana.org/assignments/media-types/application/vnd.api+json
 ,3DGEOVOLUMES,http://www.opengis.net/def/interface/ogcapi-3d-geo-volumes
 http://publications.europa.eu/resource/authority/file-type/7Z,7Z,
 http://publications.europa.eu/resource/authority/file-type/AAB,AAB,


### PR DESCRIPTION
Improvements to media type handling:

* [`ckanext/schemingdcat/codelists/inspire/csv/file-type.csv`](diffhunk://#diff-b9780889a3d84bf83113c820c90e6f92a77b53458e6735d5152fe091dac84288R2): Added a new file type entry for API with its corresponding media type.

Enhancements to format processing:

* [`ckanext/schemingdcat/profiles/eu_dcat_ap_base.py`](diffhunk://#diff-f1ba937a56f0cfc8af59f205dec1cdb6cd9e9d0f5637b983a249fbca9f9d7dacL790-R791): Modified the `mimetype` and `format` fields to strip whitespace and convert the format to uppercase.
* [`ckanext/schemingdcat/profiles/eu_dcat_ap_base.py`](diffhunk://#diff-f1ba937a56f0cfc8af59f205dec1cdb6cd9e9d0f5637b983a249fbca9f9d7dacL812-R823): Updated the logic for creating custom IMT formats by removing redundant stripping and uppercasing of the format label and adding the media type to the distribution if it is a valid IANA media type.