### PR TITLE
Fix string cleaning utility to enhance format handling in BaseEuDCATAPProfile

### DIFF
--- a/ckanext/schemingdcat/profiles/base.py
+++ b/ckanext/schemingdcat/profiles/base.py
@@ -690,6 +690,22 @@ class SchemingDCATRDFProfile(RDFProfile):
         except (ValueError, DecimalException):
             return value
 
+    def _clean_string(self, value: str, upper: bool = False) -> str:
+        """
+        Clean string value, optionally convert to uppercase.
+
+        Args:
+            value (str): The string value to be cleaned.
+            upper (bool): If True, convert the cleaned string to uppercase. Defaults to False.
+
+        Returns:
+            str: The cleaned string, optionally converted to uppercase.
+        """
+        if not value:
+            return ""
+        cleaned = value.strip()
+        return cleaned.upper() if upper else cleaned
+
     def _is_valid_access_service(self, access_service_dict: dict) -> bool:
         """Validate required properties for DataService.
         Args:

--- a/ckanext/schemingdcat/profiles/base.py
+++ b/ckanext/schemingdcat/profiles/base.py
@@ -699,10 +699,10 @@ class SchemingDCATRDFProfile(RDFProfile):
             upper (bool): If True, convert the cleaned string to uppercase. Defaults to False.
 
         Returns:
-            str: The cleaned string, optionally converted to uppercase.
-        """
-        if not value:
-            return ""
+            Optional[str]: The cleaned string, optionally converted to uppercase, or None if the input is not a string.
+       """
+        if not isinstance(value, str) or not value:
+            return None
         cleaned = value.strip()
         return cleaned.upper() if upper else cleaned
 

--- a/ckanext/schemingdcat/profiles/eu_dcat_ap_base.py
+++ b/ckanext/schemingdcat/profiles/eu_dcat_ap_base.py
@@ -787,8 +787,8 @@ class BaseEuDCATAPProfile(SchemingDCATRDFProfile):
                 )
 
             # Format
-            mimetype = resource_dict.get("mimetype").strip()
-            fmt = resource_dict.get("format").strip().upper()
+            mimetype = self._clean_string(resource_dict.get("mimetype"))
+            fmt = self._clean_string(resource_dict.get("format"), upper=True)
 
             # mediaType only IANA. IANA media types (either URI or Literal) should be mapped as mediaType.
             # In case format is available and mimetype is not set or identical to format,


### PR DESCRIPTION
## New Helper Method:
* Added `_clean_string` method to clean string values and optionally convert them to uppercase in `ckanext/schemingdcat/profiles/base.py`. This method trims whitespace and can convert strings to uppercase if specified.

