### PR TITLE
Refactor tag value retrieval logic in SchemingDCATRDFProfile to improve handling of empty labels and streamline return values

### DIFF
--- a/ckanext/schemingdcat/profiles/base.py
+++ b/ckanext/schemingdcat/profiles/base.py
@@ -435,16 +435,20 @@ class SchemingDCATRDFProfile(RDFProfile):
         Returns:
             str or None: The value found in the codelist, or None if not found and return_value is False.
         """
-        inspire_dict = {row[input_field_name].lower(): row[output_field_name] for row in metadata_codelist}
-        tag_val = inspire_dict.get(label.lower(), None)
-        if not return_value and tag_val is None:
+        
+        if not label:
             return None
-        elif not return_value and tag_val:
-            return tag_val        
-        elif return_value == True and tag_val is None:
-            return label
-        else:
+        
+        inspire_dict = {
+            row[input_field_name].lower(): row[output_field_name] 
+            for row in metadata_codelist
+        }
+        tag_val = inspire_dict.get(label.lower())
+        
+        if not return_value:
             return tag_val
+        
+        return label if tag_val is None else tag_val
 
     # ckanext-dcat fixes
     ## https://github.com/mjanez/ckanext-dcat/issues/4


### PR DESCRIPTION
This pull request includes changes to the `_search_value_codelist` method in the `ckanext/schemingdcat/profiles/base.py` file to improve readability and logic flow. The most important changes include restructuring the dictionary creation and conditional checks.

Improvements to readability and logic flow:

* [`ckanext/schemingdcat/profiles/base.py`](diffhunk://#diff-af84e6aedaa6d0d2aae3b1ff2c8a2b093a6e64a73de234728aa0145b8ebf5399L438-R452): Moved the check for an empty `label` to the beginning of the method, ensuring early return if `label` is not provided.
* [`ckanext/schemingdcat/profiles/base.py`](diffhunk://#diff-af84e6aedaa6d0d2aae3b1ff2c8a2b093a6e64a73de234728aa0145b8ebf5399L438-R452): Simplified the conditional logic by removing redundant checks and combining return statements.
* [`ckanext/schemingdcat/profiles/base.py`](diffhunk://#diff-af84e6aedaa6d0d2aae3b1ff2c8a2b093a6e64a73de234728aa0145b8ebf5399L438-R452): Reformatted the dictionary comprehension for better readability.