### PR TITLE
Improve temporal and frequency nodes.

### DIFF
--- a/ckanext/schemingdcat/config/metadata.py
+++ b/ckanext/schemingdcat/config/metadata.py
@@ -221,23 +221,57 @@ BASE_VOCABS = {
     'es_publisher_org': 'http://datos.gob.es/recurso/sector-publico/org/Organismo/',
 }
 
-FREQUENCY_MAPPING = {
-    "http://publications.europa.eu/resource/authority/frequency/ANNUAL": ("years", "1", "año"),
-    "http://publications.europa.eu/resource/authority/frequency/ANNUAL_2": ("months", "6", "meses"),
-    "http://publications.europa.eu/resource/authority/frequency/ANNUAL_3": ("months", "4", "meses"),
-    "http://publications.europa.eu/resource/authority/frequency/MONTHLY": ("months", "1", "mes"),
-    "http://publications.europa.eu/resource/authority/frequency/BIMONTHLY": ("months", "2", "meses"),
-    "http://publications.europa.eu/resource/authority/frequency/WEEKLY": ("days", "7", "días"),
-    "http://publications.europa.eu/resource/authority/frequency/BIWEEKLY": ("days", "14", "días"),
-    "http://publications.europa.eu/resource/authority/frequency/DAILY": ("days", "1", "día"),
-    "http://publications.europa.eu/resource/authority/frequency/QUARTERLY": ("months", "3", "meses"),
-    "http://publications.europa.eu/resource/authority/frequency/BIENNIAL": ("years", "2", "años"),
-    "http://publications.europa.eu/resource/authority/frequency/TRIENNIAL": ("years", "3", "años"),
-    "http://publications.europa.eu/resource/authority/frequency/CONT": ("days", "1", "día"),
-    "http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT": ("days", "1", "día"),
-    "http://publications.europa.eu/resource/authority/frequency/DAILY": ("days", "1", "día"),
-    "http://publications.europa.eu/resource/authority/frequency/NEVER": ("days", "0", "día"),
-    # ...otros mapeos a convenir...
-    # Valor por defecto si no existe mapeo
-    "DEFAULT": ("days", "9999", "continuous")
+FREQUENCY_MAPPING = {      
+    # Minutes
+    "http://publications.europa.eu/resource/authority/frequency/1MIN": ("minutes", "1", {"es": "minuto", "en": "minute"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/5MIN": ("minutes", "5", {"es": "minutos", "en": "minutes"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/10MIN": ("minutes", "10", {"es": "minutos", "en": "minutes"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/15MIN": ("minutes", "15", {"es": "minutos", "en": "minutes"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/30MIN": ("minutes", "30", {"es": "minutos", "en": "minutes"}, True),
+    
+    # Hours
+    "http://publications.europa.eu/resource/authority/frequency/HOURLY": ("hours", "1", {"es": "hora", "en": "hour"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/BIHOURLY": ("hours", "2", {"es": "horas", "en": "hours"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/TRIHOURLY": ("hours", "3", {"es": "horas", "en": "hours"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/12HRS": ("hours", "12", {"es": "horas", "en": "hours"}, True),
+    
+    # Days
+    "http://publications.europa.eu/resource/authority/frequency/MONTHLY_2": ("days", "15", {"es": "días", "en": "days"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/MONTHLY_3": ("days", "10", {"es": "días", "en": "days"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/WEEKLY": ("days", "7", {"es": "días", "en": "days"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/WEEKLY_2": ("days", "3", {"es": "días", "en": "days"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/WEEKLY_3": ("days", "2", {"es": "días", "en": "days"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/BIWEEKLY": ("days", "14", {"es": "días", "en": "days"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/DAILY": ("days", "1", {"es": "día", "en": "day"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/DAILY_2": ("hours", "12", {"es": "horas", "en": "hours"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/CONT": ("days", "1", {"es": "día", "en": "day"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/UPDATE_CONT": ("days", "1", {"es": "día", "en": "day"}, True),
+    
+    # Months
+    "http://publications.europa.eu/resource/authority/frequency/MONTHLY": ("months", "1", {"es": "mes", "en": "month"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/BIMONTHLY": ("months", "2", {"es": "meses", "en": "months"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/ANNUAL_2": ("months", "6", {"es": "meses", "en": "months"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/ANNUAL_3": ("months", "4", {"es": "meses", "en": "months"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/QUARTERLY": ("months", "3", {"es": "meses", "en": "months"}, True),
+
+    # Years
+    "http://publications.europa.eu/resource/authority/frequency/ANNUAL": ("years", "1", {"es": "año", "en": "year"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/BIENNIAL": ("years", "2", {"es": "años", "en": "years"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/TRIENNIAL": ("years", "3", {"es": "años", "en": "years"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/QUADRENNIAL": ("years", "4", {"es": "años", "en": "years"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/QUINQUENNIAL": ("years", "5", {"es": "años", "en": "years"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/DECENNIAL": ("years", "10", {"es": "años", "en": "years"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/BIDECENNIAL": ("years", "20", {"es": "años", "en": "years"}, True),
+    "http://publications.europa.eu/resource/authority/frequency/TRIDECENNIAL": ("years", "30", {"es": "años", "en": "years"}, True),
+    
+    # Special values without numerical value in the label
+    "http://publications.europa.eu/resource/authority/frequency/NEVER": ("days", "0", {"es": "nunca", "en": "never"}, False),
+    "http://publications.europa.eu/resource/authority/frequency/NOT_PLANNED": ("days", "0", {"es": "no planificado", "en": "not planned"}, False),   
+    
+    # Other - special values without numerical value
+    "http://publications.europa.eu/resource/authority/frequency/IRREG": ("days", "0", {"es": "irregular", "en": "irregular"}, False),
+    "http://publications.europa.eu/resource/authority/frequency/UNKNOWN": ("days", "0", {"es": "desconocido", "en": "unknown"}, False),
+    "http://publications.europa.eu/resource/authority/frequency/OTHER": ("days", "0", {"es": "otro", "en": "other"}, False),
+    "http://publications.europa.eu/resource/authority/frequency/OP_DATPRO": ("days", "0", {"es": "en proceso", "en": "in process"}, False),
+    "http://publications.europa.eu/resource/authority/frequency/AS_NEEDED": ("days", "0", {"es": "según necesidad", "en": "as needed"}, False),
 }

--- a/ckanext/schemingdcat/profiles/dcat_config.py
+++ b/ckanext/schemingdcat/profiles/dcat_config.py
@@ -43,7 +43,7 @@ DCATUS = Namespace("http://resources.data.gov/ontology/dcat-us#")
 VCARD = Namespace("http://www.w3.org/2006/vcard/ns#")
 FOAF = Namespace("http://xmlns.com/foaf/0.1/")
 SCHEMA = Namespace("http://schema.org/")
-TIME = Namespace("http://www.w3.org/2006/time")
+TIME = Namespace("http://www.w3.org/2006/time#")  # correct with trailing #
 LOCN = Namespace("http://www.w3.org/ns/locn#")
 GSP = Namespace("http://www.opengis.net/ont/geosparql#")
 OWL = Namespace("http://www.w3.org/2002/07/owl#")
@@ -342,8 +342,7 @@ dcat_ap_default_licenses = {
 es_dcat_literals_to_check = [
             DCT.title,
             DCT.description,
-            DCAT.keyword,
-            RDFS.label,        
+            DCAT.keyword,     
         ]
 
 # DCAT-AP-ES Literals to check default lang ("es")


### PR DESCRIPTION
### Frequency Metadata Enhancements:
* [`ckanext/schemingdcat/config/metadata.py`](diffhunk://#diff-21efa2adc02172d286546b040bb97896a93457adf5d339abd9fcda19a840a7b1L225-R276): Updated the `FREQUENCY_MAPPING` dictionary to include more granular time intervals and multilingual labels.
* [`ckanext/schemingdcat/profiles/base.py`](diffhunk://#diff-af84e6aedaa6d0d2aae3b1ff2c8a2b093a6e64a73de234728aa0145b8ebf5399R1496-R1581): Added the `_add_frequency_value` method to handle frequency metadata using the TIME ontology with multilingual labels.

### RDF Graph Management:
* [`ckanext/schemingdcat/profiles/dcat/es_dcat.py`](diffhunk://#diff-d322c022b67c558af3669f4c9f1dc3e010a1bc0acdc2be4db0fa631c84ca2d68L288-R300): Modified the `_graph_from_dataset_nti_risp` method to ensure proper removal of existing RDF triples before adding new ones for temporal and format properties. [[1]](diffhunk://#diff-d322c022b67c558af3669f4c9f1dc3e010a1bc0acdc2be4db0fa631c84ca2d68L288-R300) [[2]](diffhunk://#diff-d322c022b67c558af3669f4c9f1dc3e010a1bc0acdc2be4db0fa631c84ca2d68R358-R366) [[3]](diffhunk://#diff-d322c022b67c558af3669f4c9f1dc3e010a1bc0acdc2be4db0fa631c84ca2d68R525-R528)

### Namespace Corrections:
* [`ckanext/schemingdcat/profiles/dcat_config.py`](diffhunk://#diff-cd7873f86611a01bfe0b0fcb63b9e7fdf3d54ff7762d46f0b0019f15e7df5a42L46-R46): Corrected the `TIME` namespace to include the trailing `#`.

### Code Cleanup:
* [`ckanext/schemingdcat/profiles/dcat/es_dcat.py`](diffhunk://#diff-d322c022b67c558af3669f4c9f1dc3e010a1bc0acdc2be4db0fa631c84ca2d68L547-L573): Removed the outdated `_get_frequency_value` method, which has been replaced by the new `_add_frequency_value` method.

These changes collectively improve the accuracy and flexibility of frequency metadata handling and ensure the integrity of RDF graphs in the `ckanext/schemingdcat` extension.