### PR TITLE
Fix publisher_details bug in eu_dcat_ap_base

### DIFF
--- a/ckanext/schemingdcat/profiles/eu_dcat_ap_base.py
+++ b/ckanext/schemingdcat/profiles/eu_dcat_ap_base.py
@@ -416,6 +416,17 @@ class BaseEuDCATAPProfile(SchemingDCATRDFProfile):
         catalog_publisher_identifier = config.get(CATALOG_PUBLISHER_IDENTIFIER_CONFIG, None)
         catalog_publisher_type = config.get(CATALOG_PUBLISHER_TYPE_CONFIG, eu_dcat_ap_default_values["publisher_type"])
 
+        # Initialize publisher_details at the beginning to avoid "referenced before assignment" errors
+        # This will be used as fallback and potentially overridden if more specific publisher info is available
+        catalog_publisher_info = schemingdcat_get_catalog_publisher_info()
+        publisher_details = {
+            "name": catalog_publisher_info.get("name"),
+            "email": catalog_publisher_info.get("email"),
+            "url": catalog_publisher_info.get("url"),
+            "type": catalog_publisher_info.get("type"),
+            "identifier": catalog_publisher_info.get("identifier"),
+        }
+
         # Basic fields
         title_key = (
             "title_translated"


### PR DESCRIPTION
Initialization of `publisher_details`:

* [`ckanext/schemingdcat/profiles/eu_dcat_ap_base.py`](diffhunk://#diff-f1ba937a56f0cfc8af59f205dec1cdb6cd9e9d0f5637b983a249fbca9f9d7dacR419-R429): Added initialization of the `publisher_details` variable at the beginning of the `_graph_from_dataset_base` method to ensure it is properly set up and to avoid potential errors.…for specific publisher info