### PR TITLE
Replace basestring with str for type checks in harvesters and validators

### DIFF
--- a/ckanext/schemingdcat/harvesters/ckan.py
+++ b/ckanext/schemingdcat/harvesters/ckan.py
@@ -1,5 +1,4 @@
 from builtins import str
-from past.builtins import basestring
 import json
 import logging
 from functools import lru_cache
@@ -104,7 +103,7 @@ class SchemingDCATCKANHarvester(SchemingDCATHarvester):
         # Check if the schema is specified
         if "schema" in config_obj:
             schema = config_obj["schema"]
-            if not isinstance(schema, basestring):
+            if not isinstance(schema, str):
                 raise ValueError("schema must be a string")
 
             # Check if the specified schema is supported

--- a/ckanext/schemingdcat/harvesters/sql/base.py
+++ b/ckanext/schemingdcat/harvesters/sql/base.py
@@ -1,7 +1,6 @@
 import logging
 import json
 import traceback
-from past.builtins import basestring
 import dateutil
 from urllib.parse import urlparse, urlunparse
 from abc import ABC, abstractmethod
@@ -122,7 +121,7 @@ class SchemingDCATSQLHarvester(SchemingDCATHarvester):
         if 'database_type' in config:
             database_type = config_obj['database_type']
             log.debug("database_type: %s ", database_type)
-            if not isinstance(database_type, basestring):
+            if not isinstance(database_type, str):
                 raise ValueError('database_type must be a string')
 
             if database_type not in supported_types:

--- a/ckanext/schemingdcat/harvesters/xls.py
+++ b/ckanext/schemingdcat/harvesters/xls.py
@@ -1,5 +1,4 @@
 from builtins import str
-from past.builtins import basestring
 import json
 import logging
 import re
@@ -534,7 +533,7 @@ class SchemingDCATXLSHarvester(SchemingDCATHarvester):
         # Check the storage type of the remote file
         if 'storage_type' in config:
             storage_type = config_obj['storage_type']
-            if not isinstance(storage_type, basestring):
+            if not isinstance(storage_type, str):
                 raise ValueError('storage_type must be a string')
 
             if storage_type not in supported_types:
@@ -552,7 +551,7 @@ class SchemingDCATXLSHarvester(SchemingDCATHarvester):
                                             ('distribution_id_colname', 'resource_id')]:
             if mapping_name in config:
                 mapping_value = config_obj[mapping_name]
-                if not isinstance(mapping_value, (basestring, type(None))):
+                if not isinstance(mapping_value, (str, type(None))):
                     raise ValueError(f'{mapping_name} must be a string or None')
             else:
                 if mapping_name == 'distribution_prefix_colnames':
@@ -564,7 +563,7 @@ class SchemingDCATXLSHarvester(SchemingDCATHarvester):
         # Check the name of the dataset sheet in the remote table
         if 'dataset_sheet' in config:
             dataset_sheet = config_obj['dataset_sheet']
-            if not isinstance(dataset_sheet, basestring):
+            if not isinstance(dataset_sheet, str):
                 raise ValueError('dataset_sheet must be a string')
     
             config = json.dumps({**config_obj, 'dataset_sheet': dataset_sheet.strip()})
@@ -575,14 +574,14 @@ class SchemingDCATXLSHarvester(SchemingDCATHarvester):
         # Check the name of the distribution and data dictionary (resourcedictionary) sheets in the remote table
         if 'distribution_sheet' in config:
             distribution_sheet = config_obj['distribution_sheet']
-            if not isinstance(distribution_sheet, basestring):
+            if not isinstance(distribution_sheet, str):
                 raise ValueError('distribution_sheet must be a string')
 
             config = json.dumps({**config_obj, 'distribution_sheet': distribution_sheet.strip()})
     
         if 'datadictionary_sheet' in config:
             datadictionary_sheet = config_obj['datadictionary_sheet']
-            if not isinstance(datadictionary_sheet, basestring):
+            if not isinstance(datadictionary_sheet, str):
                 raise ValueError('datadictionary_sheet must be a string')
 
             config = json.dumps({**config_obj, 'datadictionary_sheet': datadictionary_sheet.strip()})
@@ -693,7 +692,7 @@ class SchemingDCATXLSHarvester(SchemingDCATHarvester):
         # Check if dataset_id_field exists and is a string
         if 'dataset_id_field' in config_obj:
             dataset_id_field = config_obj['dataset_id_field']
-            if not isinstance(dataset_id_field, basestring):
+            if not isinstance(dataset_id_field, str):
                 raise ValueError('dataset_id_field must be a string')
 
         return config

--- a/ckanext/schemingdcat/lib/sql_field_mapping.py
+++ b/ckanext/schemingdcat/lib/sql_field_mapping.py
@@ -1,6 +1,5 @@
 import re
 import logging
-from past.builtins import basestring
 
 log = logging.getLogger(__name__)
 
@@ -115,7 +114,7 @@ class SqlFieldMappingValidator(FieldMappingValidator):
         Raises:
             ValueError: If the value is not in the format of a database key.
         """
-        if isinstance(value, basestring):
+        if isinstance(value, str):
             value_split = value.split('.')
             if len(value_split) != 3:
                 raise ValueError('The field: "%s" should be in the format: {schema}.{table}.{field}. It currently has "%d" parts: "%s"' % (local_field, len(value_split), value))


### PR DESCRIPTION
Changes to improve compatibility with Python 3:

* [`ckanext/schemingdcat/harvesters/ckan.py`](diffhunk://#diff-dd0f7a130b3a0172bdc41a515999353ebadcfb8abbeed00183449f1e828ad01bL2): Removed the import of `basestring` from `past.builtins` and replaced its usage with `str` in the `validate_config` method. [[1]](diffhunk://#diff-dd0f7a130b3a0172bdc41a515999353ebadcfb8abbeed00183449f1e828ad01bL2) [[2]](diffhunk://#diff-dd0f7a130b3a0172bdc41a515999353ebadcfb8abbeed00183449f1e828ad01bL107-R106)
* [`ckanext/schemingdcat/harvesters/sql/base.py`](diffhunk://#diff-5535e34a9006a35cf3ec2bbe44dca7e7fef96257c4e5e8686a582fb1a3c58a15L4): Removed the import of `basestring` from `past.builtins` and replaced its usage with `str` in the `validate_config` method. [[1]](diffhunk://#diff-5535e34a9006a35cf3ec2bbe44dca7e7fef96257c4e5e8686a582fb1a3c58a15L4) [[2]](diffhunk://#diff-5535e34a9006a35cf3ec2bbe44dca7e7fef96257c4e5e8686a582fb1a3c58a15L125-R124)
* [`ckanext/schemingdcat/harvesters/xls.py`](diffhunk://#diff-537e4dbd470f429da37512b36ecb1ea1b29c912b0e621ed525308d1ae5c4bad3L2): Removed the import of `basestring` from `past.builtins` and replaced its usage with `str` in multiple instances within the `validate_config` method. [[1]](diffhunk://#diff-537e4dbd470f429da37512b36ecb1ea1b29c912b0e621ed525308d1ae5c4bad3L2) [[2]](diffhunk://#diff-537e4dbd470f429da37512b36ecb1ea1b29c912b0e621ed525308d1ae5c4bad3L537-R536) [[3]](diffhunk://#diff-537e4dbd470f429da37512b36ecb1ea1b29c912b0e621ed525308d1ae5c4bad3L555-R554) [[4]](diffhunk://#diff-537e4dbd470f429da37512b36ecb1ea1b29c912b0e621ed525308d1ae5c4bad3L567-R566) [[5]](diffhunk://#diff-537e4dbd470f429da37512b36ecb1ea1b29c912b0e621ed525308d1ae5c4bad3L578-R584) [[6]](diffhunk://#diff-537e4dbd470f429da37512b36ecb1ea1b29c912b0e621ed525308d1ae5c4bad3L696-R695)
* [`ckanext/schemingdcat/lib/sql_field_mapping.py`](diffhunk://#diff-3b17e860831c24ac9255699b95b3834d634874634e6b8c52fde2d720a98b41a3L3): Removed the import of `basestring` from `past.builtins` and replaced its usage with `str` in the `_is_not_db_key` method. [[1]](diffhunk://#diff-3b17e860831c24ac9255699b95b3834d634874634e6b8c52fde2d720a98b41a3L3) [[2]](diffhunk://#diff-3b17e860831c24ac9255699b95b3834d634874634e6b8c52fde2d720a98b41a3L118-R117)