### PR TITLE
Remove non-theme elements from dataset and catalog graphs in EsNTIRISPProfile

### DIFF
--- a/ckanext/schemingdcat/profiles/dcat/es_dcat.py
+++ b/ckanext/schemingdcat/profiles/dcat/es_dcat.py
@@ -232,6 +232,10 @@ class EsNTIRISPProfile(EuDCATAPProfile):
         # Remove language with URI if exists
         for language_uri in self.g.objects(dataset_ref, DCT.language):
             self.g.remove((dataset_ref, DCT.language, language_uri))
+            
+        # Remove other themes (DCAT-AP/NTI-RISP)
+        for non_theme_es in self.g.objects(dataset_ref, DCAT.theme):
+            self.g.remove((dataset_ref, DCAT.theme, non_theme_es))
 
         # NTI-RISP Mandatory. The publisher is a DIR3 identifier: https://datos.gob.es/es/recurso/sector-publico/org/Organismo
         catalog_publisher_info = schemingdcat_get_catalog_publisher_info()
@@ -407,6 +411,10 @@ class EsNTIRISPProfile(EuDCATAPProfile):
         # Remove language with URI if exists
         for language_uri in self.g.objects(catalog_ref, DCT.language):
             self.g.remove((catalog_ref, DCT.language, language_uri))
+
+        # Remove other themes (DCAT-AP/INSPIRE)
+        for non_theme_es in self.g.objects(catalog_ref, DCAT.themeTaxonomy):
+            self.g.remove((catalog_ref, DCAT.themeTaxonomy, non_theme_es))
 
         # Mandatory elements by NTI-RISP (datos.gob.es)
         items_core = [


### PR DESCRIPTION
This pull request includes changes to the `ckanext/schemingdcat/profiles/dcat/es_dcat.py` file to ensure proper removal of non-relevant themes in both dataset and catalog graphs.

Improvements to theme removal:

* [`ckanext/schemingdcat/profiles/dcat/es_dcat.py`](diffhunk://#diff-d322c022b67c558af3669f4c9f1dc3e010a1bc0acdc2be4db0fa631c84ca2d68R236-R239): Added logic to remove non-relevant themes (DCAT-AP/NTI-RISP) from datasets in the `_graph_from_dataset_nti_risp` method.
* [`ckanext/schemingdcat/profiles/dcat/es_dcat.py`](diffhunk://#diff-d322c022b67c558af3669f4c9f1dc3e010a1bc0acdc2be4db0fa631c84ca2d68R415-R418): Added logic to remove non-relevant themes (DCAT-AP/INSPIRE) from catalogs in the `_graph_from_catalog_nti_risp` method.