### PR TITLE
Updated contact validator to make it not overwrite manually changed values

### DIFF
--- a/ckanext/schemingdcat/validators.py
+++ b/ckanext/schemingdcat/validators.py
@@ -1251,10 +1251,11 @@ def schemingdcat_contact_as_default_publisher(field, schema):
             
             fallback_value = CONTACT_PUBLISHER_FALLBACK.get(field_name, None)
             
-            if fallback_value and 'ckanext.schemingdcat' in fallback_value:
-                data[key] = config.get(fallback_value)
-            elif fallback_value:
-                data[key] = fallback_value
+            if not data.get(key):
+                if fallback_value and 'ckanext.schemingdcat' in fallback_value:
+                    data[key] = config.get(fallback_value)
+                elif fallback_value:
+                    data[key] = fallback_value
             
             if fallback_value is None:
                 data[key] = None


### PR DESCRIPTION
updated `schemingdcat_contact_as_default_publisher` to check if value already exists, so it doesn't alwais overwrite fields