### PR TITLE
Enhance access services in CSWSchemingdcatHarvester

### DIFF
--- a/ckanext/schemingdcat/config/harvest_csw.py
+++ b/ckanext/schemingdcat/config/harvest_csw.py
@@ -737,3 +737,5 @@ DCAT_SERVICE_TYPES = {
         }
     }
 }
+
+OGC_SERVICES_LIST = ['WMS', 'WFS', 'WCS', 'CSW', 'SOS', 'WMTS']

--- a/ckanext/schemingdcat/helpers.py
+++ b/ckanext/schemingdcat/helpers.py
@@ -8,7 +8,7 @@ from yaml.loader import SafeLoader
 from pathlib import Path
 from functools import lru_cache
 import datetime
-from urllib.parse import urlparse, unquote, urljoin
+from urllib.parse import urlparse, unquote, urljoin, urlunparse
 from urllib.error import URLError
 from six.moves.urllib.parse import urlencode
 import typing
@@ -2112,3 +2112,41 @@ def schemingdcat_user_is_org_member(
 @helper
 def schemingdcat_get_catalog_publisher_info():
     return sdct_config.catalog_publisher_info
+
+@helper
+def schemingdcat_extract_base_url(url):
+    """
+    Extract the base URL without query parameters or fragments.
+    Preserves the path including file extensions like .aspx, .php, etc.
+    
+    Args:
+        url (str): The full URL
+        
+    Returns:
+        str: The base URL without query parameters
+        
+    Examples:
+        >>> _extract_base_url("https://wms.mapama.es/sig/Agua/ZonasProtPotablesPoligonos/2027/wms.aspx?service=WMS")
+        'https://wms.mapama.es/sig/Agua/ZonasProtPotablesPoligonos/2027/wms.aspx'
+        
+        >>> _extract_base_url("https://www.mapa.gob.es/app/descargas/descargafichero.aspx?f=ComarcasAgrarias.rar")
+        'https://www.mapa.gob.es/app/descargas/descargafichero.aspx'
+    """
+    try:        
+        # Parse the URL
+        parsed = urlparse(url)
+        
+        # Reconstruct the URL without query parameters and fragments
+        clean_url = urlunparse((
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            '',  # params
+            '',  # query
+            ''   # fragment
+        ))
+        
+        return clean_url
+        
+    except Exception as e:
+        return url


### PR DESCRIPTION
Enhancements to URL handling and metadata extraction:

* [`ckanext/schemingdcat/config/harvest_csw.py`](diffhunk://#diff-c868baa1513e8f7d3755f3cdb8564101bcd137905b28c58df1dac44ee7ba0422R740-R741): Added a list of OGC services to facilitate URL standardization.
* [`ckanext/schemingdcat/helpers.py`](diffhunk://#diff-e64da4110d9ba359d43b9c56c5b0fa58a60136b682bac02f3ca9ee9e53cc969aR2115-R2152): Introduced `schemingdcat_extract_base_url` helper function to extract base URLs without query parameters or fragments.
* [`ckanext/schemingdcat/lib/csw/csw_metadata_extractor.py`](diffhunk://#diff-fed313857d5bb13a29dd4e63d82912695bd7aab3951c857426b2ae89aa5163d9R903-R931): Updated the `_extract_distributions` method to standardize OGC service URLs by appending GetCapabilities requests if missing.
* [`ckanext/schemingdcat/lib/csw/csw_metadata_extractor.py`](diffhunk://#diff-fed313857d5bb13a29dd4e63d82912695bd7aab3951c857426b2ae89aa5163d9L1033-R1080): Modified the `_extract_access_services` method to add service standard URIs to the `conforms_to` field in the resource dictionary.
* [`ckanext/schemingdcat/lib/csw/csw_metadata_extractor.py`](diffhunk://#diff-fed313857d5bb13a29dd4e63d82912695bd7aab3951c857426b2ae89aa5163d9L1013-R1040): Refactored the `_extract_access_services` method to use the new `schemingdcat_extract_base_url` function for extracting base URLs.