### PR TITLE
Fix schemingdcat_dataset_url validator

### DIFF
--- a/ckanext/schemingdcat/validators.py
+++ b/ckanext/schemingdcat/validators.py
@@ -1321,6 +1321,14 @@ def schemingdcat_dataset_url(field, schema):
     """
     def validator(key, data, errors, context):
         dataset_id = data.get(('id', ))
-        data[key] = ckan_helpers.url_for('dataset.read', id=dataset_id, _external=True)
-
+        package_type = data.get(('type', ), 'dataset')
+        if dataset_id:
+            data[key] = ckan_helpers.url_for(
+                'dataset.read',
+                id=dataset_id,
+                package_type=package_type,
+                _external=True
+            )
+        else:
+            data[key] = ''
     return validator


### PR DESCRIPTION
### Key changes:
* **Improved URL generation logic in `schemingdcat_dataset_url`:**
  - Added support for specifying `package_type` when generating dataset URLs. Defaults to `'dataset'` if not provided.
  - Added a fallback to set the URL to an empty string when `dataset_id` is not available.

Avoid errors like:
```log
werkzeug.routing.BuildError: Could not build url for endpoint 'dataset.read'. Did you forget to specify values ['id', 'package_type']?
```